### PR TITLE
Task #244166 fix: Update action log entry to allow null remarks in applications service

### DIFF
--- a/src/applications/applications.service.ts
+++ b/src/applications/applications.service.ts
@@ -178,8 +178,8 @@ export class ApplicationsService {
 						ip: normalFields.ip || 'Unknown',
 						updatedAt: new Date(),
 					},
-					'resubmit',
-					'Application resubmitted with updated data'
+					'application_resubmitted',
+					null
 				);
 
 				// Update existing action log or create new one
@@ -218,8 +218,8 @@ export class ApplicationsService {
 				ip: normalFields.ip || 'Unknown',
 				updatedAt: new Date(),
 			},
-			'submit',
-			'Application submitted successfully'
+			'application_submitted',
+			null
 		);
 
 		const created = await this.prisma.applications.create({
@@ -527,7 +527,7 @@ export class ApplicationsService {
 	getActionLogEntry(
 		actionLog: UpdateApplicationActionLogDto,
 		status: string,
-		remark: string,
+		remark: string | null,
 	) {
 		return JSON.stringify({
 			...actionLog,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Update action log entry to allow null remarks

- Change action status strings to more descriptive names

- Fix type signature for remark parameter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["getActionLogEntry method"] --> B["Allow null remarks"]
  A --> C["Update status strings"]
  B --> D["application_submitted"]
  B --> E["application_resubmitted"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>applications.service.ts</strong><dd><code>Update action log entry method signature and status strings</code></dd></summary>
<hr>

src/applications/applications.service.ts

<ul><li>Modified <code>getActionLogEntry</code> method to accept null remarks parameter<br> <li> Updated action status from 'submit' to 'application_submitted'<br> <li> Updated action status from 'resubmit' to 'application_resubmitted'<br> <li> Replaced hardcoded remark strings with null values</ul>


</details>


  </td>
  <td><a href="https://github.com/tekdi/ubi-strapi-provider-mw/pull/116/files#diff-0c7634960e6f90d650763d2db2fedac76398f50f9b55387c76ae532179b7c1a7">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

