### PR TITLE
Bug #245486 fix: Draft Schemes Visible on Provider Side

### DIFF
--- a/src/benefits/benefits.service.ts
+++ b/src/benefits/benefits.service.ts
@@ -77,12 +77,20 @@ export class BenefitsService {
 		const locale = body?.locale ?? 'en';
 		const filters = body?.filters ?? {};
 
+		// Add filter for published benefits
+		const publishedFilters = {
+			...filters,
+			publishedAt: {
+				$notNull: true,
+			},
+		};
+
 		const queryParams = {
 			page,
 			pageSize,
 			sort,
 			locale,
-			filters,
+			filters: publishedFilters,
 		};
 
 		const queryString = qs.stringify(queryParams, {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Filter out draft benefits by adding `publishedAt` not null condition

- Prevent unpublished benefits from appearing on provider side


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original filters"] --> B["Add publishedAt filter"]
  B --> C["Only published benefits returned"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>benefits.service.ts</strong><dd><code>Add published filter to benefits query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/benefits/benefits.service.ts

<ul><li>Added <code>publishedAt: { $notNull: true }</code> filter to existing filters<br> <li> Ensures only published benefits are returned in search results<br> <li> Prevents draft schemes from being visible on provider side</ul>


</details>


  </td>
  <td><a href="https://github.com/tekdi/ubi-strapi-provider-mw/pull/126/files#diff-f360204932834de6193768dbb3ed72b86bb7ca047cb964bd4a45818a991e434d">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

