### PR TITLE
Bug #245486 fix: Draft Schemes Visible on Provider Side

### DIFF
--- a/src/benefits/benefits.service.ts
+++ b/src/benefits/benefits.service.ts
@@ -103,6 +103,13 @@ export class BenefitsService {
 			headers,
 		});
 
+		// Filter benefits to only include published ones
+		if (response?.data?.results) {
+			response.data.results = response.data.results.filter(
+				(benefit: any) => benefit.status === 'published'
+			);
+		}
+
 		// Check if the response contains results
 		if (response?.data?.results.length > 0) {
 			const enrichedData = await Promise.all(


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Changed filtering approach for published benefits from query-time to response-time

- Replaced `publishedAt` filter with `status === 'published'` check

- Moved filtering logic from request parameters to response processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Request with filters"] --> B["Remove publishedAt filter"]
  B --> C["Send request to API"]
  C --> D["Filter response by status"]
  D --> E["Return only published benefits"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>benefits.service.ts</strong><dd><code>Changed benefits filtering from query to response level</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/benefits/benefits.service.ts

<ul><li>Removed <code>publishedAt</code> filter from query parameters<br> <li> Added post-response filtering by <code>status === 'published'</code><br> <li> Moved filtering logic from request construction to response processing</ul>


</details>


  </td>
  <td><a href="https://github.com/tekdi/ubi-strapi-provider-mw/pull/127/files#diff-f360204932834de6193768dbb3ed72b86bb7ca047cb964bd4a45818a991e434d">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

